### PR TITLE
Update to allow to force low quality capture.

### DIFF
--- a/src/android/nl/xservices/plugins/videocaptureplus/VideoCapturePlus.java
+++ b/src/android/nl/xservices/plugins/videocaptureplus/VideoCapturePlus.java
@@ -136,6 +136,9 @@ public class VideoCapturePlus extends CordovaPlugin {
 
     if (highquality) {
       intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
+    } else {
+      // If high quality set to false, force low quality for devices that default to high quality
+      intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 0);
     }
 
     if (frontcamera) {


### PR DESCRIPTION
With the intent of capturing video for upload, allow to capture video in low quality.  Since many devices default to HQ, setting the highquality param to false still results in high quality.
