### PR TITLE
Update VideoCapturePlus.java

### DIFF
--- a/src/android/nl/xservices/plugins/videocaptureplus/VideoCapturePlus.java
+++ b/src/android/nl/xservices/plugins/videocaptureplus/VideoCapturePlus.java
@@ -169,6 +169,8 @@ public class VideoCapturePlus extends CordovaPlugin {
       missingPermissions = new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.RECORD_AUDIO};
     } else if (!writePermission && !cameraPermission && recordAudioPermission) {
       missingPermissions = new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE,Manifest.permission.CAMERA};
+	} else if (!writePermission && cameraPermission && recordAudioPermission) {
+	  missingPermissions = new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE};
     } else if (!writePermission && !cameraPermission && !recordAudioPermission) {
       missingPermissions = permissions;
     }


### PR DESCRIPTION
If Mic and Camera permissions are granted but storage is not, the plugin will fail. This fixes that.